### PR TITLE
Change event loop policy for win32

### DIFF
--- a/connectedpapers/connected_papers_client.py
+++ b/connectedpapers/connected_papers_client.py
@@ -11,6 +11,9 @@ import nest_asyncio  # type: ignore
 from .consts import ACCESS_TOKEN, CONNECTED_PAPERS_REST_API
 from .graph import Graph, PaperID
 
+import sys
+if sys.platform == 'win32':
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 class GraphResponseStatuses(Enum):
     """Statuses for API"""


### PR DESCRIPTION
Avoids the following error in windows:
    RuntimeError: There is no current event loop.